### PR TITLE
Konflux Dockerfile for Red Hat Jenkins

### DIFF
--- a/REDHAT_README.md
+++ b/REDHAT_README.md
@@ -1,0 +1,44 @@
+# Red Hat Build of Jenkins Controller Image
+
+This is a fork of the upstream [jenkinsci/docker](https://github.com/jenkinsci/docker) repository
+which includes a separate Dockerfile for assembling a "clean" Jenkins image (located in
+`rhel/ubi9/konflux`). This image can be run with Podman or any other container engine using the
+same instructions in the main [README](./README.md). It does not contain any plugins for running
+Jenkins pipelines or adding integrations for OpenShift.
+
+## Branch Configuration
+
+This fork should be align with upstream Jenkins to the furthest extent possible. The default
+`master` branch should be kept in sync with the upstream repository.
+Red Hat releases should use the branch convention `rh-jenkins-<version>`, where `<version>` is the
+major and minor semantic version of the core Jenkins .war that is packaged. For example, the `2.462.z` LTS releases should use the branch name `rh-jenkins-2.462`.
+
+## Onboarding to Konflux
+
+The Dockerfile for building on [Konflux](https://konflux-ci.dev) should be kept in the
+`rhel/ubi<N>/konflux` directory, where `<N>` is the major version of UBI used to assemble the
+image. For example, `ubi9` base images should use the directory `rhel/ubi9/konflux` to place the
+Dockerfile.
+
+The Dockerfile for Konflux has several notable differences:
+
+- We use our fork of [go-init](https://github.com/redhat-openshift-jenkins/go-init) as the main
+  entrypoint. We have used this as the entrypoint for OpenShift's Jenkins since 2019, and it has
+  proved itself stable in production. Upstream uses [tini](https://github.com/krallin/tini), which
+  is C-based and provides almost identical functionality. `go-init` must be onboarded to Konflux
+  and marked as a dependency. The binary is extracted from the component's container image.
+- The core Jenkins .war file is extracted from the respective Konflux image. The `jenkins.war` file
+  is likewise extracted from the component's container image, and must be marked as a dependency in
+  Konflux.
+- Ditto for the plugin manager .jar - it is extracted from the respective Konflux image.
+- Rather than use standard UBI as the base (with some hacking to slim down the JDK), the Konflux
+  Dockerfile uses standard "runtime" images published by Red Hat's OpenJDK maintainers. Notable
+  differences are:
+    - Images are currently `ubi-micro` based. For ubi9, `microdnf` is used to install RHEL
+      packages.
+    - `JAVA_HOME` is pre-set in the image, we do not provide our own "slim" JDK.
+    - OpenJDK images create their own "default" user, which is separate from the "jenkins" user the
+      image defaults to. Currently the UID for `default` (185) and `jenkins` (1000) do not collide.
+      File permissions and the `HOME` environment variable are set accordingly so Jenkins runs in a
+      secure manner by default.
+

--- a/rhel/ubi9/konflux/Dockerfile
+++ b/rhel/ubi9/konflux/Dockerfile
@@ -1,0 +1,105 @@
+FROM quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-jenkins-2-462/go-init-2-462@sha256:8244f9bfe9da17b34c83d5bad6f031f623c49e353abb0dd38249eb3bc53cb622 as go-init
+
+FROM quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-jenkins-2-462/jenkins-war@sha256:de13a4065d020d8d5e68d5642d6a2f606093600d9e91a6a65dedf88b2a0c47df as jenkins-war
+
+FROM quay.io/redhat-user-workloads/rh-openshift-builds-tenant/openshift-jenkins-2-462/jenkins-plugin-manager-2-462@sha256:538cf5c12819550d2565a5132daef6fcf33a25b4328e37d345504a769fc3e30c as plugin-manager
+
+FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.20-2.1724037300 AS controller
+
+USER root
+
+ENV LANG=C.UTF-8
+
+ARG TARGETARCH
+ARG COMMIT_SHA
+
+# ubi9/openjdk-*-runtime images are based on ubi-minimal, which uses microdnf.
+RUN microdnf install --disableplugin=subscription-manager --setopt=install_weak_deps=0 --setopt=tsflags=nodocs -y \
+        fontconfig \
+        freetype \
+        git \
+        git-lfs \
+        unzip \
+        which \
+        tzdata \
+    && microdnf clean --disableplugin=subscription-manager all
+
+ARG user=jenkins
+ARG group=jenkins
+ARG uid=1000
+ARG gid=1000
+ARG http_port=8080
+ARG agent_port=50000
+ARG JENKINS_HOME=/var/jenkins_home
+ARG REF=/usr/share/jenkins/ref
+
+ENV JENKINS_HOME=$JENKINS_HOME
+ENV JENKINS_SLAVE_AGENT_PORT=${agent_port}
+ENV REF=$REF
+
+# Jenkins is run with user `jenkins`, uid = 1000
+# If you bind mount a volume from the host or a data container,
+# ensure you use the same uid
+RUN mkdir -p $JENKINS_HOME \
+  && chown ${uid}:${gid} $JENKINS_HOME \
+  && groupadd -g ${gid} ${group} \
+  && useradd -N -d "$JENKINS_HOME" -u ${uid} -g ${gid} -l -m -s /bin/bash ${user}
+
+# Jenkins home directory is a volume, so configuration and build history
+# can be persisted and survive image upgrades
+VOLUME $JENKINS_HOME
+
+# $REF (defaults to `/usr/share/jenkins/ref/`) contains all reference configuration we want
+# to set on a fresh new installation. Use it to bundle additional plugins
+# or config file with your custom jenkins Docker image.
+RUN mkdir -p ${REF}/init.groovy.d
+
+# Replace upstream use of tini with go-init.
+# chown to root:root so the "jenkins" user cannot modify.
+COPY --from=go-init --chown=root:root /usr/bin/go-init /usr/bin/go-init
+
+# Extract jenkins.war from the container image build of core Jenkins
+# chown to root:root so the "jenkins" user cannot modify
+COPY --from=jenkins-war --chown=root:root /deployments/jenkins.war /usr/share/jenkins/jenkins.war
+
+ENV JENKINS_UC=https://updates.jenkins.io
+ENV JENKINS_UC_EXPERIMENTAL=https://updates.jenkins.io/experimental
+ENV JENKINS_INCREMENTALS_REPO_MIRROR=https://repo.jenkins-ci.org/incrementals
+RUN chown -R ${user} "$JENKINS_HOME" "$REF"
+
+# Extract plugin manager from the component image build
+# chown to root:root so the "jenkins" user cannot modify
+COPY --from=plugin-manager --chown=root:root /deployments/jenkins-plugin-manager.jar /opt/jenkins-plugin-manager.jar
+
+# for main web interface:
+EXPOSE ${http_port}
+
+# will be used by attached agents:
+EXPOSE ${agent_port}
+
+ENV COPY_REFERENCE_FILE_LOG=$JENKINS_HOME/copy_reference_file.log
+
+USER ${user}
+# UBI9 JDK images use /home/default as a working directory, which is owned by the "default" user.
+# Upstream Jenkins images use "/" as the working directory by default.
+WORKDIR "/"
+# UBI9 JDK images set the HOME env var to /home/default, which is owned by the "default" user.
+# Update HOME env var to match JENKINS_HOME.
+ENV HOME=$JENKINS_HOME
+
+COPY jenkins-support /usr/local/bin/jenkins-support
+COPY jenkins.sh /usr/local/bin/jenkins.sh
+COPY jenkins-plugin-cli.sh /bin/jenkins-plugin-cli
+
+# Use go-init instead of tini for ENTRYPOINT
+ENTRYPOINT ["/usr/bin/go-init", "-main", "/usr/local/bin/jenkins.sh"]
+
+# metadata labels
+LABEL \
+    org.opencontainers.image.vendor="Red Hat" \
+    org.opencontainers.image.title="Red Hat Build of Jenkins Container Image" \
+    org.opencontainers.image.description="The Jenkins Continuous Integration and Delivery server. Built by Red Hat." \
+    org.opencontainers.image.version="2.462" \
+    org.opencontainers.image.url="https://www.jenkins.io/" \
+    org.opencontainers.image.source="https://github.com/redhat-openshift-jenkins/jenkinsci-docker" \
+    org.opencontainers.image.licenses="MIT"


### PR DESCRIPTION
Adding a Dockerfile for building Jenkins on Konflux. This is a copy of the ubi9/hotspot Dockerfile with a few critical variations:

- Use openjdk runtime image (21) as base
- Copy jenkins.war from Konflux component build.
- Replace tini with go-init, built on Konflux as a component.
- Source the plugin manaer from the respective Konflux image.
- Update image metadata to indicate this is built by Red Hat.
- Adjust environment variables and working directory so they align with the upstream Jenkins image (published on DockerHub).

These modifications are documented in the REDHAT_README.md file. This will help future maintainers understand the key differences between the upstream UBI image and the "intermediate" image that is built on Konflux.

This image intentionally does not install any plugins or configure Jenkins to mark itself "ready"/"initialized" by default. It instead serves as the base for our OpenShift plugin test images and the final Jenkins controller image for OpenShift. Keeping this repo "clean" minimizes potential merge/behavior conflicts when rebasing or cherry- picking upstream changes.